### PR TITLE
Updated discord_rig_bot to rig-core@0.9 and added some fixes for Discord responses

### DIFF
--- a/discord_rig_bot/Cargo.toml
+++ b/discord_rig_bot/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-rig-core = "0.2.1"
+rig-core = "0.9"
 tokio = { version = "1.34.0", features = ["full"] }
 serenity = { version = "0.11", default-features = false, features = ["client", "gateway", "rustls_backend", "cache", "model", "http"] }
 dotenv = "0.15.0"

--- a/discord_rig_bot/src/rig_agent.rs
+++ b/discord_rig_bot/src/rig_agent.rs
@@ -1,15 +1,16 @@
 // rig_agent.rs
 
 use anyhow::{Context, Result};
-use rig::providers::openai;
-use rig::vector_store::in_memory_store::InMemoryVectorStore;
-use rig::vector_store::VectorStore;
-use rig::embeddings::EmbeddingsBuilder;
-use rig::agent::Agent;
-use rig::completion::Prompt;
-use std::path::Path;
+use rig::{
+    agent::Agent, completion::Prompt, embeddings::EmbeddingsBuilder, providers::openai,
+    vector_store::in_memory_store::InMemoryVectorStore,
+};
 use std::fs;
+use std::path::Path;
 use std::sync::Arc;
+
+use serenity::client::Context as SerenityContext;
+use serenity::model::channel::Message;
 
 pub struct RigAgent {
     agent: Arc<Agent<openai::CompletionModel>>,
@@ -37,36 +38,40 @@ impl RigAgent {
         let md2_content = Self::load_md_content(&md2_path)?;
         let md3_content = Self::load_md_content(&md3_path)?;
 
-        // Create embeddings and add to vector store
+        //Create embeddings add to vector store
         let embeddings = EmbeddingsBuilder::new(embedding_model.clone())
-            .simple_document("Rig_guide", &md1_content)
-            .simple_document("Rig_faq", &md2_content)
-            .simple_document("Rig_examples", &md3_content)
+            .document(md1_content)?
+            .document(md2_content)?
+            .document(md3_content)?
             .build()
             .await?;
 
-        vector_store.add_documents(embeddings).await?;
+        vector_store.add_documents(embeddings);
 
         // Create index
         let index = vector_store.index(embedding_model);
 
         // Create Agent
-        let agent = Arc::new(openai_client.agent(openai::GPT_4O)
-            .preamble("You are an advanced AI assistant powered by Rig, a Rust library for building LLM applications. Your primary function is to provide accurate, helpful, and context-aware responses by leveraging both your general knowledge and specific information retrieved from a curated knowledge base.
+        let agent = Arc::new(
+            openai_client
+                .agent(openai::GPT_4O)
+                .preamble(
+                    "You are an advanced AI assistant powered by Rig, a Rust library for building LLM applications. Your primary function is to provide accurate, helpful, and context-aware responses by leveraging both your general knowledge and specific information retrieved from a curated knowledge base.
 
                     Key responsibilities and behaviors:
                     1. Information Retrieval: You have access to a vast knowledge base. When answering questions, always consider the context provided by the retrieved information.
                     2. Clarity and Conciseness: Provide clear and concise answers. Ensure responses are short and concise. Use bullet points or numbered lists for complex information when appropriate.
                     3. Technical Proficiency: You have deep knowledge about Rig and its capabilities. When discussing Rig or answering related questions, provide detailed and technically accurate information.
-                    4. Code Examples: When appropriate, provide Rust code examples to illustrate concepts, especially when discussing Rig's functionalities. Always format code examples for proper rendering in Discord by wrapping them in triple backticks and specifying the language as 'rust'. For example:
+                    5. Code Examples: When appropriate, provide Rust code examples to illustrate concepts, especially when discussing Rig's functionalities. Always format code examples for proper rendering in Discord by wrapping them in triple backticks and specifying the language as 'rust'. For example:
                         ```rust
                         let example_code = \"This is how you format Rust code for Discord\";
                         println!(\"{}\", example_code);
                         ```
-                    5. Keep your responses short and concise. If the user needs more information, they can ask follow-up questions.
-                    ")
-            .dynamic_context(2, index)
-            .build());
+                ",
+                )
+                .dynamic_context(2, index)
+                .build(),
+    );
 
         Ok(Self { agent })
     }
@@ -75,8 +80,43 @@ impl RigAgent {
         fs::read_to_string(file_path.as_ref())
             .with_context(|| format!("Failed to read markdown file: {:?}", file_path.as_ref()))
     }
-
-    pub async fn process_message(&self, message: &str) -> Result<String> {
-        self.agent.prompt(message).await.map_err(anyhow::Error::from)
+    
+    // Add this function for messages that only need a string input/output
+    pub async fn process_string(&self, message: &str) -> Result<String> {
+        self.agent
+            .prompt(message)
+            .await
+            .map_err(anyhow::Error::from)
     }
+    
+    pub async fn process_message(&self, ctx: &SerenityContext, msg: &Message) -> Result<String> {
+        // First, create a typing indicator
+        msg.channel_id.broadcast_typing(&ctx.http).await?;
+        
+        // Send deferred response to meet 3-second requirement
+        let mut deferred_msg = msg.channel_id.say(&ctx.http, "Thinking...").await?;
+        
+        // Use the string content directly, not a reference
+        let response = self.agent.prompt(msg.content.clone()).await.map_err(anyhow::Error::from)?;
+        
+        // Truncate if needed
+        let truncated_response = if response.len() > 1900 {
+            format!("Response truncated due to Discord limits:\n{}", &response[..1897])
+        } else {
+            response
+        };
+        
+        // Edit the deferred message
+        deferred_msg.edit(&ctx.http, |m| m.content(truncated_response.clone())).await?;
+        
+        Ok(truncated_response)
+    }
+
+    // OLD process_message WITHOUT DEFERRAL AND TRUNCATION
+    // pub async fn process_message(&self, message: &str) -> Result<String> {
+    //     self.agent
+    //         .prompt(message)
+    //         .await
+    //         .map_err(anyhow::Error::from)
+    // }
 }


### PR DESCRIPTION
I was getting a bunch of `The application did not respond` messages in Discord.  For example `/ask what is rig?` would give me that error, but `/ask what is rig in just a few words?` would work properly.

Turns out Discord has a rule that it only waits 3 seconds for a response, so if your LLM takes too long to respond, you will get that message.  Also, Discord limits each message to 2000 characters (unless you have Nitro--then you get 4000).  I modified process_messages to add a deferral response and truncate any message over 1900 characters.

I also updated the code to work with rig-core@0.9 whereas the original code used 0.2.1.  I am new to rig so these updates may not be optimal, but the code compiles and works.  Unfortunately the changes do make the code more difficult to understand.
