### PR TITLE
Add rig-redis-vectorstore to Libraries and Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These sources are useful for finding additional projects that depend on Rig:
 - [weavegraph](https://github.com/Idleness76/weavegraph) - Graph-driven concurrent agent workflow framework with versioned state and deterministic merges.
 - [rig-dyn](https://github.com/GustavoWidman/rig-dyn) - Dynamic client-provider abstraction layer on top of `rig-core`.
 - [rig-extra](https://github.com/launcher-rs/rig-extra-project) - Lightweight extensions built on top of `rig-core`.
+- [rig-redis-vectorstore](https://github.com/daric93/rig-redis-vectorstore) - Redis (RediSearch) vector store integration for Rig with KNN similarity search, metadata filtering, and configurable distance metrics ([crates.io](https://crates.io/crates/rig-redis-vectorstore)).
 
 ## Applications
 


### PR DESCRIPTION
Adds `rig-redis-vectorstore` to the Libraries and Frameworks list.

It's a community-maintained Redis ([RediSearch](https://redis.io/docs/latest/develop/ai/search-and-query/)) vector store integration for Rig, implementing `VectorStoreIndex`, `InsertDocuments`, and `VectorStoreIndexDyn` over `FT.SEARCH` KNN, with metadata filtering and configurable distance metrics (COSINE/L2/inner product).

- Crate: https://crates.io/crates/rig-redis-vectorstore
- Docs: https://docs.rs/rig-redis-vectorstore
- Repo: https://github.com/daric93/rig-redis-vectorstore

The entry is a single factual sentence, publicly accessible, depends on `rig-core` from crates.io, and is placed alphabetically among the other `rig-*` entries.