### PR TITLE
Add Archestra to Production Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ These companies and teams publicly mention Rig usage in the upstream README or e
 - [Syncable](https://syncable.dev/) - Uses Rig in its CLI.
 - [Refresh Agent](https://refreshagent.com/) - Uses Rig for SEO and marketing-analysis agents.
 - [nitpik](https://nitpik.dev/) - Uses Rig under the hood for AI code reviews.
+- [Archestra](https://github.com/archestra-ai/archestra) - MCP-native secure AI platform. Uses Rig in its agentic benchmark.
 
 ## Articles and Talks
 


### PR DESCRIPTION
Adds [Archestra](https://github.com/archestra-ai/archestra), an MCP-native secure AI platform, to the Production Users section. It uses Rig in its agentic benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)