### PR TITLE
Add taquba-research to Applications -> Agents, Assistants, and RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ These sources are useful for finding additional projects that depend on Rig:
 - [Amico](https://github.com/AIMOverse/amico) - AI agent framework with SDK and plugins.
 - [termai](https://github.com/JazzyMcJazz/termai) - AI assistant for the terminal.
 - [squid](https://github.com/DenysVuika/squid) - AI-powered command-line code review and suggestion tool.
+- [taquba-research](https://github.com/micllam/taquba-research) - Reference implementation of a durable Rig agent: a research CLI that plans, searches the web, reads pages, and synthesizes cited reports, with multi-step runs persisted to object storage so they resume after a crash.
 
 ### Domain-Specific Projects
 


### PR DESCRIPTION
Adds taquba-research to Applications -> Agents, Assistants, and RAG.

taquba-research is a durable Rig agent: a research CLI that plans, searches the web, reads pages, and synthesizes cited reports, with multi-step runs persisted to object storage and completed model calls memoized, so a run resumes after a crash without re-paying for work already done.

It's a worked example of a durable-agent pattern: Rig's LLM orchestration over durable, object-storage-backed execution.